### PR TITLE
feat: add delete section button next to add card button

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,6 +21,7 @@ const translations: Record<Language, Record<string, string>> = {
 		'common.confirmDeleteMessage': 'Are you sure you want to delete this? This action cannot be undone.',
 		'common.delete': 'Delete',
 			'card.deleted': 'Card deleted',
+			'section.deleted': 'Section deleted',
 
 		// Settings
 		'settings.dashboardFile': 'Dashboard file',
@@ -313,6 +314,7 @@ const translations: Record<Language, Record<string, string>> = {
 		'common.confirmDeleteMessage': '确定要删除吗？此操作无法撤销。',
 		'common.delete': '删除',
 			'card.deleted': '卡片已删除',
+			'section.deleted': '分区已删除',
 
 		// Settings
 		'settings.dashboardFile': '仪表盘文件',

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -435,7 +435,7 @@ function renderSection(column: DashboardColumn, callbacks: RenderCallbacks, app:
 		saveCollapsedSections(collapsed);
 	});
 
-		const headerActions = header.createDiv({ cls: 'dashboard-section-header-actions' });
+	const headerActions = header.createDiv({ cls: 'dashboard-section-header-actions' });
 
 	if (sectionType === 'todo') {
 		const templateBtn = headerActions.createEl('button', {
@@ -452,6 +452,16 @@ function renderSection(column: DashboardColumn, callbacks: RenderCallbacks, app:
 	});
 	setIcon(addCardBtn, 'plus');
 	addCardBtn.addEventListener('click', () => callbacks.onCardAdd(column.name));
+
+	const deleteBtn = headerActions.createEl('button', {
+		cls: 'dashboard-section-add-btn dashboard-section-delete-btn',
+		attr: { 'aria-label': t('renderer.deleteSection', { column: column.name }) },
+	});
+	setIcon(deleteBtn, 'trash-2');
+	deleteBtn.addEventListener('click', (e) => {
+		e.stopPropagation();
+		callbacks.onColumnDelete(column.name);
+	});
 
 	const cardsContainer = el.createDiv({ cls: 'dashboard-section-cards' });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export interface RenderCallbacks {
 	onCardGridMove(cardId: string, gridCol: number, gridRow: number): void;
 	onFileDrop(cardId: string, filePath: string): void;
 	onColumnRename(oldName: string, newName: string): void;
+	onColumnDelete(name: string): void;
 	onTaskReminderEdit(cardId: string, taskIndex: number, reminder: string | undefined): void;
 	onAddFromTemplate(columnName: string): void;
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -524,6 +524,15 @@ export class DashboardView extends ItemView {
 				onCardGridMove: (cardId: string, gridCol: number, gridRow: number) => this.sync.updateCardGridMove(cardId, gridCol, gridRow),
 				onFileDrop: (cardId: string, filePath: string) => this.handleFileDrop(cardId, filePath),
 				onColumnRename: (oldName: string, newName: string) => this.sync.renameColumn(oldName, newName),
+			onColumnDelete: async (name: string) => {
+				const confirmed = await showConfirmDialog(this.app, {
+					title: t('common.confirmDelete'),
+					message: t('common.confirmDeleteMessage'),
+				});
+				if (!confirmed) return;
+				this.sync.deleteColumn(name);
+				new Notice(t('section.deleted'));
+			},
 			onTaskReminderEdit: (cardId: string, taskIndex: number, reminder: string | undefined) => this.sync.editTaskReminder(cardId, taskIndex, reminder),
 			onAddFromTemplate: (columnName: string) => this.openTemplatePicker(columnName),
 		};

--- a/styles.css
+++ b/styles.css
@@ -2796,8 +2796,12 @@
 .dashboard-section-header-actions {
 	display: flex;
 	align-items: center;
-	gap: 2px;
+	gap: 4px;
 	flex-shrink: 0;
+}
+
+.dashboard-section-delete-btn:hover {
+	color: var(--db-error, #e53e3e) !important;
 }
 
 .dashboard-add-section-row {


### PR DESCRIPTION
更新概要
- 板块标题的加号按钮旁新增删除图标按钮
- 点击删除按钮弹出确认弹窗，确认后即可删除对应板块
- 新增按钮统一收纳至弹性布局容器，界面排布更整洁

代码改动
- src/types.ts：渲染回调中新增栏目删除回调方法
- src/renderer.ts：将删除按钮与新增按钮整合布局
- src/view.ts：编写栏目删除回调逻辑并搭配确认弹窗
- src/i18n.ts：补充栏目删除相关中英双语文案
- styles.css：添加按钮容器样式与删除按钮悬浮效果

备注
- 栏目删除核心逻辑需在 src/sync.ts 文件中实现，相关代码不在本次仓库内；同时已新增对应国际化字段。修改完成后执行 npm run build 命令，重新编译生成主程序文件即可。